### PR TITLE
fix: 解决格式化代码后，npm run dev报错

### DIFF
--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -156,7 +156,7 @@ const handleClickOutside = () => {
 		.sidebar {
 			pointer-events: none;
 			// transition-duration: 0.3s;
-			transform: translate3d(- v.$sideBarWidth, 0, 0);
+			transform: translate3d(-#{v.$sideBarWidth}, 0, 0);
 		}
 	}
 }


### PR DESCRIPTION
执行npm run format后会报错，因为- v.$sideBarWidth中间的空格被删掉了。